### PR TITLE
Fixed auth token including quotes

### DIFF
--- a/src/tesla-app.js
+++ b/src/tesla-app.js
@@ -210,7 +210,7 @@ function loginToTesla(config, callback) {
             process.exit(1);
         }
 
-        var token = JSON.stringify(result.authToken);
+        var token = result.authToken;
 
         if (token) {
             console.log("Login Succesful!");


### PR DESCRIPTION
Fixed issue where the login token was being quoted within the actual token string, causing it to be invalid when used.